### PR TITLE
Ændringsforslag: Fjern taleret til alle fra Fællesrtådet og alle fra …

### DIFF
--- a/SIGMA_statut.tex
+++ b/SIGMA_statut.tex
@@ -75,7 +75,7 @@ Denne gruppe af uddannelser betegnes herefter Faggruppen.
 \subsection{}Kassereren er forpligtiget til at bistå revisorerne med fremskaffelse af kontoudtog og øvrige bilag til regnskabet.
 
 \section{Studentermøder}\label{par:studmdr}
-\subsection{}På Studentermøderne har alle studerende ved Faggruppen tale- og stemmeret og herudover har repræsentanter fra Fællesrådet og andre studenterpolitiske organisationer ved \fakultetet ved Aarhus Universitet taleret.
+\subsection{}På Studentermøderne har alle studerende ved Faggruppen tale- og stemmeret.
 
 \subsection{}Studentermødet kan herudover vælge at lade andre deltagere end de ovennævnte have taleret.
 \subsection{}Studentermødet ledes af en dirigent, der vælges af og blandt de tilstedeværende.


### PR DESCRIPTION
…fakultetet

Indsendt af Rune N. T. Thorsen
Det giver ikke mening, at alle i Fællesrådet og alle studerende på fakultetet ud over Faggruppen har taleret til Studentermøderne.