### PR TITLE
Ændringsforslag: Fjern §1 stk. 5

### DIFF
--- a/SIGMA_statut.tex
+++ b/SIGMA_statut.tex
@@ -50,7 +50,6 @@
 \end{itemize}
 Denne gruppe af uddannelser betegnes herefter Faggruppen.
 \subsection{}\foreningen har til formål at virke til gavn for de studerende i Faggruppen ved at varetage deres fælles faglige, økonomiske og sociale interesser. Arbejdet er uafhængigt af politiske og økonomiske interesser.
-\subsection{}\foreningen udgør Faggruppens repræsentation ved Studenterrådet ved Aarhus Universitet og lader sig derfor repræsentere i Fællesrådet.
 
 \section{Struktur og tegning}
 \subsection{}\foreningen s øverste myndighed er generelforsamlingen.


### PR DESCRIPTION
Indsendt af Rune N. T. Thorsen.
Stykket får det til at lyde som om, vi ikke er uafhængige af Studenterrådet. Givet §1 stk. 4 er den også overflødig ifht. Studenterrådets statut, jvf. Studenterrådets statut §2, §9 og §10.